### PR TITLE
설정 파일 application.yml  에 h2 설정을 추가하라

### DIFF
--- a/adapters/persistence/adapter-maria/src/main/java/com/sweet/AdapterMaria.java
+++ b/adapters/persistence/adapter-maria/src/main/java/com/sweet/AdapterMaria.java
@@ -1,0 +1,13 @@
+package com.sweet;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class AdapterMaria {
+
+    public static void main(String[] args) {
+        SpringApplication.run(AdapterMaria.class, args);
+    }
+
+}

--- a/adapters/persistence/adapter-maria/src/main/resources/application.yml
+++ b/adapters/persistence/adapter-maria/src/main/resources/application.yml
@@ -1,10 +1,27 @@
 spring:
+  profiles:
+    active: local
+
+# local environment
+---
+spring:
+  profiles: local
   h2:
     console:
       enabled: true
       path: /h2
   datasource:
     driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:test
+    url: jdbc:h2:tcp://localhost/~/test
     username: sa
     password:
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    show_sql: true
+    hibernate:
+      ddl-auto: create-drop
+      naming:
+        implicit-strategy: org.springframework.boot.orm.jpa.hibernate.SpringImplicitNamingStrategy
+    properties:
+      hibernate:
+        format_sql: true


### PR DESCRIPTION
* application.yml 수정 사항
  * spring.profiles.active: local 추가
    * local 환경에서는 h2 가 실행되도록 설정하였습니다. 
    * 추후, maria DB 를 연결하기 위해, spring.profiles.active 설정을 나누었습니다.
  * h2 설정은 local 에서만 사용되기 때문에, show_sql, format_sql true 설정
  * hibernate 의 naming 은 디폴트 값, SpringImplicitNamingStrategy 명시
    * 테이블과 컬럼명이 snake 표현으로 설정되도록 하였습니다. ex) OrderItem -> order_item
  * ddl-auto: create-drop 
    * Application 이 올라갈 때, 생성 및 삭제되도록 설정했습니다.
* @ SpringBootApplication 를 가진 AdapterMaria class 를 추가