### PR TITLE
설정 파일 docker-compose.yml 을 생성하여 mariadb를 띄워라

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,5 +11,5 @@ services:
       - ~/docker/mariadb/var/lib/mysql:/var/lib/mysql
       - ~/docker/mariadb/var/log/maria:/var/log/maria
     environment:
-      - MYSQL_ROOT_PASSWORD=???
+      - MYSQL_ROOT_PASSWORD=1234
       - TZ="Asia/Seoul"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.1'
+services:
+  maria:
+    image: mariadb:latest
+    container_name: "mariadb"
+    restart: always
+    ports:
+      - "63306:3306"
+    volumes:
+      - ~/docker/mariadb/etc/mysql/conf.d:/etc/mysql/conf.d:ro
+      - ~/docker/mariadb/var/lib/mysql:/var/lib/mysql
+      - ~/docker/mariadb/var/log/maria:/var/log/maria
+    environment:
+      - MYSQL_ROOT_PASSWORD=???
+      - TZ="Asia/Seoul"


### PR DESCRIPTION
* 작업 내용
  * docker-compose.yml 를 생성하여 mariadb 를 띄울 수 있도록 설정하였습니다.

&nbsp;

* homebrew 설치
```
/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
```
* docker 설치
```
brew cask install docker
```
* docker compose 설치
 ```
sudo curl -L https://github.com/docker/compose/releases/download/1.18.0/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
 ```
* docker compose 권한 설정
```
sudo chmod +x /usr/local/bin/docker-compose
```
* docker compose 실행
```
docker-compose up
```

* 참고 사항
  * [home brew cask  설명](https://www.cprime.com/resources/blog/docker-on-mac-with-homebrew-a-step-by-step-tutorial/)
  * [docker-compose 참고](https://www.44bits.io/ko/post/almost-perfect-development-environment-with-docker-and-docker-compose)
  * [docker-compose 명령어 참고](https://4urdev.tistory.com/81)