### PR TITLE
docker DB 접속정보, character 정보를 추가하라

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,5 +11,11 @@ services:
       - ~/docker/mariadb/var/lib/mysql:/var/lib/mysql
       - ~/docker/mariadb/var/log/maria:/var/log/maria
     environment:
-      - MYSQL_ROOT_PASSWORD=1234
-      - TZ="Asia/Seoul"
+      MYSQL_ROOT_PASSWORD: 1234
+      MYSQL_DATABASE: caregiver_salrong
+      MYSQL_USER: caregiver
+      MYSQL_PASSWORD: 1234
+      TZ: Asia/Seoul
+    command:
+      --character-set-server=utf8mb4
+      --collation-server=utf8mb4_unicode_ci


### PR DESCRIPTION
- DB 접속 정보를 추가했습니다.

- DB character 정보를 추가했습니다.

- 로컬에서 DB 접속 시도시 실패할경우 ~/docker/mariadb 디렉토리를 제거한뒤 재 시도바랍니다.