### PR TITLE
Spring REST Docs 설정을 추가하라

### DIFF
--- a/adapters/web/adapter-client-api/src/test/java/com/caregiver/common/ApiDocumentUtils.java
+++ b/adapters/web/adapter-client-api/src/test/java/com/caregiver/common/ApiDocumentUtils.java
@@ -1,0 +1,18 @@
+package com.caregiver.common;
+
+import org.springframework.restdocs.operation.preprocess.OperationRequestPreprocessor;
+import org.springframework.restdocs.operation.preprocess.OperationResponsePreprocessor;
+
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+
+public class ApiDocumentUtils {
+  public static OperationRequestPreprocessor getDocumentRequest() {
+    return preprocessRequest(prettyPrint());
+  }
+
+  public static OperationResponsePreprocessor getDocumentResponse() {
+    return preprocessResponse(prettyPrint());
+  }
+}

--- a/adapters/web/adapter-client-api/src/test/java/com/caregiver/common/BaseControllerTest.java
+++ b/adapters/web/adapter-client-api/src/test/java/com/caregiver/common/BaseControllerTest.java
@@ -2,23 +2,28 @@ package com.caregiver.common;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 
-@ExtendWith(SpringExtension.class)
-public class BaseControllerTest {
-
+@ExtendWith({SpringExtension.class, RestDocumentationExtension.class})
+public abstract class BaseControllerTest {
   protected MockMvc mockMvc;
 
   @BeforeEach
-  void setUp(WebApplicationContext webApplicationContext) {
+  void setUp(WebApplicationContext webApplicationContext,
+             RestDocumentationContextProvider restDocumentation) {
+
     this.mockMvc = MockMvcBuilders
         .webAppContextSetup(webApplicationContext)
+        .apply(documentationConfiguration(restDocumentation))
         .addFilters(new CharacterEncodingFilter("UTF-8", true))
         .alwaysDo(print())
         .build();

--- a/adapters/web/adapter-client-api/src/test/java/com/caregiver/user/controller/SignUpControllerTest.java
+++ b/adapters/web/adapter-client-api/src/test/java/com/caregiver/user/controller/SignUpControllerTest.java
@@ -6,9 +6,19 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.test.web.servlet.ResultActions;
 
-import static org.springframework.http.MediaType.APPLICATION_JSON;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static com.caregiver.common.ApiDocumentUtils.getDocumentRequest;
+import static com.caregiver.common.ApiDocumentUtils.getDocumentResponse;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.JsonFieldType.BOOLEAN;
+import static org.springframework.restdocs.payload.JsonFieldType.OBJECT;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(SignUpController.class)
@@ -22,12 +32,27 @@ class SignUpControllerTest extends BaseControllerTest {
 
   @Test
   void testExample() throws Exception {
-    this.mockMvc.perform(post(URL)
-        .content("{\"userName\" : \"이지훈\", \"password\" : \"1234\"}")
-        .contentType(APPLICATION_JSON)
-        .accept(APPLICATION_JSON))
-        .andExpect(status().isCreated());
-  }
 
+    ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders.post(URL)
+        .content("{\"userName\" : \"이지훈\", \"password\" : \"1234\"}")
+        .contentType(MediaType.APPLICATION_JSON)
+    );
+
+    resultActions.andExpect(status().isCreated())
+        .andDo(document("sticker/make-sticker",
+            getDocumentRequest(),
+            getDocumentResponse(),
+            requestFields(
+                fieldWithPath("userName").description("유저 이름").type(STRING),
+                fieldWithPath("password").description("패스워드").type(STRING)
+            ),
+            responseFields(
+                fieldWithPath("success").description("성공 여부").type(BOOLEAN),
+                fieldWithPath("message").description("응답 메세지").type(STRING),
+                fieldWithPath("data").description("응답 데이터").type(OBJECT).optional()
+            )
+        ));
+
+  }
 
 }

--- a/applications/client-api/build.gradle
+++ b/applications/client-api/build.gradle
@@ -1,5 +1,20 @@
 apply plugin: 'org.asciidoctor.convert'
 
+bootJar.enabled = true
+jar.enabled = false
+
+// client Application 을 구성하는 의존성
+dependencies {
+    implementation project(':domain')
+    implementation project(':adapters:persistence:adapter-maria')
+    implementation project(':adapters:web:adapter-client-api')
+    implementation 'org.springframework.boot:spring-boot-starter'
+
+    asciidoctor 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+}
+
+// Spring REST Docs 설정
 ext {
     snippetsDir = file('build/generated-snippets')
 }
@@ -20,16 +35,3 @@ bootJar {
     }
 }
 
-bootJar.enabled = true
-jar.enabled = false
-
-// client Application 을 구성하는 의존성
-dependencies {
-    implementation project(':domain')
-    implementation project(':adapters:persistence:adapter-maria')
-    implementation project(':adapters:web:adapter-client-api')
-    implementation 'org.springframework.boot:spring-boot-starter'
-
-    asciidoctor 'org.springframework.restdocs:spring-restdocs-asciidoctor'
-    asciidoctor 'io.spring.asciidoctor:spring-asciidoctor-extensions-block-switch:0.5.1.RELEASE'
-}

--- a/applications/client-api/src/docs/asciidoc/index.adoc
+++ b/applications/client-api/src/docs/asciidoc/index.adoc
@@ -1,0 +1,187 @@
+= Caregiver Salrong API Document
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 3
+:sectlinks:
+:snippets: ../../../build/generated-snippets
+
+== 소개
+
+집사 살롱 Client API
+
+=== Domain
+
+[cols="1,3"]
+|===
+| Environment | Domain
+
+| 개발서버
+|
+
+| 운영서버
+|
+|===
+
+=== HTTP Status
+
+link:https://tools.ietf.org/html/rfc7231#section-6[RFC7231] 에 많은 HTTP 응답코드가 정의되어 있지만, 너무 많은 응답코드는 개발자에서 혼란을 초래한다.
+그렇기 때문에 다음과 같은 `HTTP Status Code` 만을 사용한다.
+
+[cols="1,2,3"]
+|===
+| Code | Name | Description
+
+| 200
+| OK
+| 요청이 성공적으로 수행
+
+| 201
+| Created
+| 요청이 성공적이었으며 그 결과로 새로운 리소스가 생성
+
+| 204
+| No Contents
+| 요청이 성공적이었으며 응답 바디 값이 없다
+
+| 400
+| Bad request
+| 이 응답은 잘못 된 문법으로 인하여 서버가 요청을 이해할 수 없을 때 사용
+
+| 401
+| Unauthorized
+| 인증 실패
+
+| 403
+| Forbidden
+| 인가 실패
+
+| 404
+| Not found
+| 리소스를 찾을 수 없음
+
+| 409
+| Conflict
+| 요청이 현재 서버의 리소스 상태와 충돌이 발생 (패스워트 불일치 등)
+
+| 500
+| Internal server error
+| 서버에 오류가 발생하여 요청을 수행할 수 없음
+
+|===
+
+=== HTTP Method
+
+아래의 `HTTP Method` 만을 사용한다.
+
+[cols="1,3"]
+|===
+| Method | Description
+
+| GET
+| GET를 통해 해당 리소스를 조회한다. 리소스를 조회하고 해당 도큐먼트에 대한 자세한 정보를 조회한다.
+
+| POST
+| POST를 통해 해당 URI를 요청하면 리소스를 생성한다.
+
+| PUT
+| PUT를 통해 해당 리소스를 전체 수정한다.
+
+| PATCH
+| PATCH를 통해 해당 리소스를 부분 수정한다.
+
+| DELETE
+| DELETE를 통해 리소스를 삭제한다.
+|===
+
+NOTE: link:https://tools.ietf.org/html/rfc7231[RFC7231], link:https://ko.wikipedia.org/wiki/HTTP[위키백과] 에 근거하여 HTTP GET Method 에는 Request Body를 포함하지 않는다.
+이러한 이유로 인해 조회 성격의 API 이지만 조회 쿼리가 복잡할 경우 POST Method 를 사용할 수 있다.
+
+=== Content Type
+
+API 성격에 상관없이 일관되지 않은 다양한 `Content-Type` 을 사용하면 API를 사용하는 클라이언트에게 혼란을 초래하게 된다.
+특별한 경우가 아닐 경우 `Content-Type` 은 `application/json;charset=utf-8` 을 통일한다.
+
+=== Header
+
+|===
+| name | 설명
+|
+|
+|===
+
+=== 공통 Response Body
+
+[source,options="nowrap"]
+----
+{
+  "success" : true,
+  "message" : null,
+  "data" : ...
+}
+----
+
+|===
+| Field | Type | Description
+
+| `success`
+| Boolean
+| 성공 여부
+
+| `message`
+| String
+| 메세지
+
+| `data`
+| API 스펙 참고
+| 결과 데이터
+|===
+
+=== 오류 Response Body
+
+HTTP Status 400 (Bad Request) 오류일 경우 입력 요청 값의 상세 오류내용이 아래의 포맷과 같이 응답된다.
+
+[source,options="nowrap"]
+----
+{
+  "success" : false,
+  "message" : "입력 값이 올바르지 않습니다.",
+  "data" : [
+    {
+      "field" : "id",
+      "reason" : "must not be blank"
+    },
+    {
+      "field" : "email",
+      "reason" : "must not be blank"
+    }
+  ]
+}
+----
+
+|===
+| Field | Type | Description
+
+| `success`
+| Boolean
+| 성공 여부
+
+| `message`
+| String
+| 메세지
+
+| `data[].field`
+| String
+| 구체적인 오류발생 필드 명
+
+| `data[].message`
+| String
+| 구체적인 오류 설명
+
+|===
+
+== 집사살롱 공통 필드값
+
+
+

--- a/applications/client-api/src/main/java/com/caregiver/AppClientApplication.java
+++ b/applications/client-api/src/main/java/com/caregiver/AppClientApplication.java
@@ -1,0 +1,13 @@
+package com.caregiver;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class AppClientApplication {
+
+  public static void main(String[] args) {
+    SpringApplication.run(AppClientApplication.class, args);
+  }
+
+}

--- a/applications/client-api/src/test/java/com/caregiver/AppClientApplicationTest.java
+++ b/applications/client-api/src/test/java/com/caregiver/AppClientApplicationTest.java
@@ -4,10 +4,10 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-public class ClientApplication {
+public class AppClientApplicationTest {
 
   public static void main(String[] args) {
-    SpringApplication.run(ClientApplication.class, args);
+    SpringApplication.run(AppClientApplicationTest.class, args);
   }
 
 }


### PR DESCRIPTION
## 작업 내용
- Spring REST Docs 설정을 추가했습니다.
- 작업내용과 무관한 (Web<->App 과 구분을 짓기 위해 클래스 명을 변경하라) 이 포함된 점 양해 바랍니다.
- `gradlew applications:client-api:clean applications:client-api:build` 명령어를 실행 후 생성된 jar 파일을 java -jar xxx.jar 로 실행 할 경우 아래 이미지를 확인 가능합니다.

![image](https://user-images.githubusercontent.com/65605968/118209759-31519b00-b4a4-11eb-9ed7-97f8baa59209.png)
