### PR TITLE
spring-boot-starter-validation 의존성을 추가하라

### DIFF
--- a/adapters/web/adapter-client-api/build.gradle
+++ b/adapters/web/adapter-client-api/build.gradle
@@ -4,5 +4,6 @@ jar.enabled = true
 dependencies {
     implementation project(':domain')
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -4,5 +4,6 @@ jar.enabled = true
 dependencies {
     implementation 'org.springframework:spring-context'
     implementation 'org.springframework:spring-tx'
-    api group: 'com.google.guava', name: 'guava', version: '29.0-jre'
+
+    api 'com.google.guava:guava:29.0-jre'
 }


### PR DESCRIPTION
## 개요 
- `web` layer 에 `spring-boot-starter-validation` 의존성 추가

## 작업 내용
- `gradle spring-boot-starter-validation` 라이브러리를 추가했습니다.

## 참고 사항
- web 영역에서 유효성검증을 하기위해 추가했습니다.

## 질문 및 논의 필요

