### PR TITLE
SendAccreditationNumberCommand의 필드를 유효성 검증하라

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -2,7 +2,9 @@ bootJar.enabled = false
 jar.enabled = true
 
 dependencies {
-    implementation 'org.springframework:spring-context'
     implementation 'org.springframework:spring-tx'
-    api group: 'com.google.guava', name: 'guava', version: '29.0-jre'
+
+    // Java Bean Validation
+    api 'org.springframework.boot:spring-boot-starter-validation'
+    api 'com.google.guava:guava:29.0-jre'
 }

--- a/common/src/main/java/com/caregiver/common/SelfValidating.java
+++ b/common/src/main/java/com/caregiver/common/SelfValidating.java
@@ -1,0 +1,37 @@
+package com.caregiver.common;
+
+
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import java.util.Set;
+
+/**
+ * Java Bean 유효성 검사를 하기 위한 클래스
+ *
+ * @param <T> 유효성 검사 대상 객체
+ */
+public abstract class SelfValidating<T extends SelfValidating<T>> {
+
+  private final Validator validator;
+
+  public SelfValidating() {
+    validator = Validation
+        .buildDefaultValidatorFactory()
+        .getValidator();
+  }
+
+  /**
+   * 이 인스턴스의 속성에 대한 모든 Bean 유효성 검사를 평가합니다.
+   *
+   * @throws ConstraintViolationException 유효성 제약을 위반한 경우
+   */
+  protected void validateSelf() {
+    Set<ConstraintViolation<SelfValidating<T>>> violations = validator.validate(this);
+    if (!violations.isEmpty()) {
+      throw new ConstraintViolationException(violations);
+    }
+  }
+
+}

--- a/domain/src/main/java/com/caregiver/user/port/in/SendAccreditationNumberUsecase.java
+++ b/domain/src/main/java/com/caregiver/user/port/in/SendAccreditationNumberUsecase.java
@@ -1,0 +1,31 @@
+package com.caregiver.user.port.in;
+
+import com.caregiver.common.SelfValidating;
+import lombok.EqualsAndHashCode;
+
+import javax.validation.constraints.NotBlank;
+
+
+/**
+ * 인증 번호 전송 Usecase
+ */
+public interface SendAccreditationNumberUsecase {
+
+  /**
+   * 주어진 휴대폰 번호를 SMS 발송서버로 전송합니다.
+   */
+  void send(SendAccreditationNumberCommand sendAccreditationNumberCommand);
+
+
+  @EqualsAndHashCode(callSuper = false)
+  class SendAccreditationNumberCommand extends SelfValidating<SendAccreditationNumberCommand> {
+
+    @NotBlank
+    private final String mobile;
+
+    public SendAccreditationNumberCommand(String mobile) {
+      this.mobile = mobile;
+      this.validateSelf();
+    }
+  }
+}

--- a/domain/src/test/java/com/caregiver/user/port/in/SendAccreditationNumberCommandTest.java
+++ b/domain/src/test/java/com/caregiver/user/port/in/SendAccreditationNumberCommandTest.java
@@ -1,0 +1,59 @@
+package com.caregiver.user.port.in;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import javax.validation.ConstraintViolationException;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayName("SendAccreditationNumberCommand 클래스")
+class SendAccreditationNumberCommandTest {
+
+  @Nested
+  @DisplayName("SendAccreditationNumberCommand 생성자는")
+  class Describe_01 {
+
+    private void subject(String mobileNumber) {
+      SendAccreditationNumberUsecase.SendAccreditationNumberCommand sendAccreditationNumberCommand =
+          new SendAccreditationNumberUsecase.SendAccreditationNumberCommand(mobileNumber);
+    }
+
+    @Nested
+    @DisplayName("휴대폰 번호가 null이 주어질 경우")
+    class Context_01 {
+
+      private final String null_인_휴대폰번호 = null;
+
+      @Test
+      @DisplayName("예외를 리턴한다.")
+      public void it_01() {
+        assertThatThrownBy(() -> subject(null_인_휴대폰번호))
+            .isInstanceOf(ConstraintViolationException.class);
+      }
+
+    }
+
+    @Nested
+    @DisplayName("공백 또는 빈 휴대폰 번호가 주어질 경우")
+    class Context_02 {
+
+      private final List<String> mobileNumbers = List.of("", "    ");
+
+      @Test
+      @DisplayName("예외를 리턴한다.")
+      public void it_01() {
+        mobileNumbers
+            .forEach(mobileNumber -> assertThatThrownBy(() -> subject(mobileNumber))
+                .isInstanceOf(ConstraintViolationException.class));
+
+      }
+
+    }
+
+  }
+
+}


### PR DESCRIPTION
## 개요 
- 인증번호 전송 명령 객체의 필드(휴대폰번호) 유효성 검증

## 작업 내용
- `common` 모듈 내 `spring-boot-stater-validation` 의존성 추가

## 참고 사항
- [Java Bean Validation 사용하기](https://do-study.tistory.com/99)

## 질문 및 논의 필요

