### PR TITLE
요청받은 휴대폰 번호를 유효성 검증하라

### DIFF
--- a/adapters/web/adapter-client-api/build.gradle
+++ b/adapters/web/adapter-client-api/build.gradle
@@ -3,6 +3,8 @@ jar.enabled = true
 
 dependencies {
     implementation project(':domain')
+    implementation project(':common')
+
     implementation 'org.springframework.boot:spring-boot-starter-web'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/adapters/web/adapter-client-api/src/main/java/com/caregiver/user/controller/MobileAuthenticationController.java
+++ b/adapters/web/adapter-client-api/src/main/java/com/caregiver/user/controller/MobileAuthenticationController.java
@@ -1,0 +1,36 @@
+package com.caregiver.user.controller;
+
+import com.caregiver.user.dto.MobileAuthenticationDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+/**
+ * 휴대폰 인증 컨트롤러
+ */
+@RestController
+@RequestMapping("/v1/mobile")
+@RequiredArgsConstructor
+public class MobileAuthenticationController {
+
+  /**
+   * 휴대폰 인증번호 발송 요청 합니다.
+   *
+   * @param request 인증번호 요청
+   */
+  @PostMapping("/accreditation-number/send-sms")
+  public ResponseEntity<?> acceptAccreditationNumber(
+      @RequestBody @Valid MobileAuthenticationDto.Request request) {
+
+    return ResponseEntity
+        .status(HttpStatus.CREATED)
+        .build();
+  }
+
+}

--- a/adapters/web/adapter-client-api/src/main/java/com/caregiver/user/dto/MobileAuthenticationDto.java
+++ b/adapters/web/adapter-client-api/src/main/java/com/caregiver/user/dto/MobileAuthenticationDto.java
@@ -1,0 +1,26 @@
+package com.caregiver.user.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class MobileAuthenticationDto {
+
+  @Getter
+  @NoArgsConstructor
+  public static class Request {
+
+    @NotBlank
+    @Pattern(regexp = "(01[0-9])-(\\d{3,4})-(\\d{4})")
+    private String mobile;
+
+    public Request(String mobile) {
+      this.mobile = mobile;
+    }
+  }
+
+}

--- a/adapters/web/adapter-client-api/src/test/java/com/caregiver/user/controller/MobileAuthenticationControllerTest.java
+++ b/adapters/web/adapter-client-api/src/test/java/com/caregiver/user/controller/MobileAuthenticationControllerTest.java
@@ -1,0 +1,87 @@
+package com.caregiver.user.controller;
+
+import com.caregiver.common.BaseControllerTest;
+import com.caregiver.user.dto.MobileAuthenticationDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EmptySource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.util.stream.Stream;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(MobileAuthenticationController.class)
+@DisplayName("MobileAuthenticationController 클래스")
+class MobileAuthenticationControllerTest extends BaseControllerTest {
+
+  private static final String URL = "/v1/mobile/accreditation-number";
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @ParameterizedTest
+  @MethodSource("provideInvalidMobileNumbers")
+  @NullSource
+  @EmptySource
+  @DisplayName(
+      "MobileAuthenticationDto.Request 는 잘못된 휴대폰 번호 필드가 주어졌을 경우 http status 400을 리턴한다"
+  )
+  void test_01(String input) throws Exception {
+
+    final MobileAuthenticationDto.Request request = new MobileAuthenticationDto.Request(input);
+
+    final String requestBody = objectMapper.writeValueAsString(request);
+
+    final ResultActions resultActions = getResultActions(requestBody);
+
+    resultActions.andExpect(status().isBadRequest());
+  }
+
+  private static Stream<Arguments> provideInvalidMobileNumbers() {
+    return Stream.of(
+        Arguments.of("    "),
+        Arguments.of("123lksdnflmk"),
+        Arguments.of("010"),
+        Arguments.of("010-"),
+        Arguments.of("010111"),
+        Arguments.of("010zaaa")
+    );
+
+  }
+
+  @Test
+  @DisplayName(
+      "MobileAuthenticationDto.Request 는 올바른 휴대폰 번호 필드가 주어졌을 경우 http status 201을 리턴한다"
+  )
+  void test_02() throws Exception {
+
+    final String mobileNumber = "010-1234-1234";
+    final MobileAuthenticationDto.Request request =
+        new MobileAuthenticationDto.Request(mobileNumber);
+
+    final String requestBody = objectMapper.writeValueAsString(request);
+
+    final ResultActions resultActions = getResultActions(requestBody);
+
+    resultActions.andExpect(status().isCreated());
+  }
+
+  private ResultActions getResultActions(String requestBody) throws Exception {
+    return mockMvc.perform(RestDocumentationRequestBuilders.post(URL)
+        .content(requestBody)
+        .contentType(MediaType.APPLICATION_JSON)
+    );
+  }
+
+
+}

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -4,5 +4,8 @@ jar.enabled = true
 dependencies {
     implementation 'org.springframework:spring-context'
     implementation 'org.springframework:spring-tx'
-    api group: 'com.google.guava', name: 'guava', version: '29.0-jre'
+
+    // Java Bean Validation
+    api 'org.springframework.boot:spring-boot-starter-validation'
+    api 'com.google.guava:guava:29.0-jre'
 }


### PR DESCRIPTION
## 개요 
- 요청받은 휴대폰 번호를 유효성 검증하라

## 작업 내용
- 휴대폰 인증번호 요청 API를 추가했습니다.
- 요청 requestDto의 휴대폰번호의 유효성 검증 테스트를 추가했습니다.
- requestDto 객체를 검증하기 위한 Controller 를 추가했습니다.

## 참고 사항
- https://bamdule.tistory.com/35

## 질문 및 논의 필요

