### PR TITLE
인증번호 발송 web <-> domain 을 연동하라

### DIFF
--- a/adapters/web/adapter-client-api/src/main/java/com/caregiver/user/controller/MobileAuthenticationController.java
+++ b/adapters/web/adapter-client-api/src/main/java/com/caregiver/user/controller/MobileAuthenticationController.java
@@ -1,6 +1,7 @@
 package com.caregiver.user.controller;
 
 import com.caregiver.user.dto.MobileAuthenticationDto;
+import com.caregiver.user.port.in.SendAccreditationNumberUsecase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -19,14 +20,19 @@ import javax.validation.Valid;
 @RequiredArgsConstructor
 public class MobileAuthenticationController {
 
+  private final SendAccreditationNumberUsecase sendAccreditationNumberUsecase;
+
   /**
    * 휴대폰 인증번호 발송 요청 합니다.
    *
-   * @param request 인증번호 요청
+   * @param request 인증번호를 요청하기위한 Dto
    */
   @PostMapping("/accreditation-number/send-sms")
+
   public ResponseEntity<?> acceptAccreditationNumber(
       @RequestBody @Valid MobileAuthenticationDto.Request request) {
+
+    sendAccreditationNumberUsecase.send(request.generateCommand());
 
     return ResponseEntity
         .status(HttpStatus.CREATED)

--- a/adapters/web/adapter-client-api/src/main/java/com/caregiver/user/dto/MobileAuthenticationDto.java
+++ b/adapters/web/adapter-client-api/src/main/java/com/caregiver/user/dto/MobileAuthenticationDto.java
@@ -1,5 +1,6 @@
 package com.caregiver.user.dto;
 
+import com.caregiver.user.port.in.SendAccreditationNumberUsecase;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -21,6 +22,14 @@ public class MobileAuthenticationDto {
     public Request(String mobile) {
       this.mobile = mobile;
     }
+
+    /**
+     * SendAccreditationNumberCommand 객체를 리턴합니다.
+     */
+    public SendAccreditationNumberUsecase.SendAccreditationNumberCommand generateCommand() {
+      return new SendAccreditationNumberUsecase.SendAccreditationNumberCommand(this.getMobile());
+    }
+
   }
 
 }

--- a/adapters/web/adapter-client-api/src/test/java/com/caregiver/user/controller/MobileAuthenticationControllerTest.java
+++ b/adapters/web/adapter-client-api/src/test/java/com/caregiver/user/controller/MobileAuthenticationControllerTest.java
@@ -2,6 +2,7 @@ package com.caregiver.user.controller;
 
 import com.caregiver.common.BaseControllerTest;
 import com.caregiver.user.dto.MobileAuthenticationDto;
+import com.caregiver.user.port.in.SendAccreditationNumberUsecase;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -12,6 +13,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.NullSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.test.web.servlet.ResultActions;
@@ -28,6 +30,9 @@ class MobileAuthenticationControllerTest extends BaseControllerTest {
 
   @Autowired
   private ObjectMapper objectMapper;
+
+  @MockBean
+  private SendAccreditationNumberUsecase sendAccreditationNumberUsecase;
 
   @ParameterizedTest
   @MethodSource("provideInvalidMobileNumbers")

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ subprojects {
 
     ext {
         springBootVersion = "2.3.4.RELEASE"
-        mockitoVersion = "3.3.3"
+        mockitoVersion = "3.4.0"
         lombokVersion = "1.18.12"
     }
 
@@ -46,6 +46,7 @@ subprojects {
         testCompileOnly 'org.assertj:assertj-core:3.16.0'
         testImplementation "org.mockito:mockito-core:${mockitoVersion}"
         testImplementation "org.mockito:mockito-junit-jupiter:${mockitoVersion}"
+        testImplementation 'org.mockito:mockito-inline:3.8.0'
     }
 
     dependencyManagement {

--- a/domain/src/main/java/com/caregiver/user/service/SendAccreditationNumberService.java
+++ b/domain/src/main/java/com/caregiver/user/service/SendAccreditationNumberService.java
@@ -1,0 +1,21 @@
+package com.caregiver.user.service;
+
+import com.caregiver.common.annotation.UseCase;
+import com.caregiver.user.port.in.SendAccreditationNumberUsecase;
+
+import static com.caregiver.common.util.AccreditationNumberUtil.generate;
+
+/**
+ * 인증번호 전송 service
+ */
+@UseCase
+public class SendAccreditationNumberService implements SendAccreditationNumberUsecase {
+
+  @Override
+  public void send(SendAccreditationNumberCommand sendAccreditationNumberCommand) {
+
+    final var accreditationNumber = generate(100_000, 1000_000);
+
+  }
+
+}

--- a/domain/src/test/java/com/caregiver/user/service/SendAccreditationNumberServiceTest.java
+++ b/domain/src/test/java/com/caregiver/user/service/SendAccreditationNumberServiceTest.java
@@ -1,0 +1,65 @@
+
+package com.caregiver.user.service;
+
+import com.caregiver.common.util.AccreditationNumberUtil;
+import com.caregiver.user.port.in.SendAccreditationNumberUsecase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayName("SendAccreditationNumberService 클래스")
+class SendAccreditationNumberServiceTest {
+
+  private SendAccreditationNumberUsecase sendAccreditationNumberService;
+
+  @BeforeEach
+  void init() {
+    this.sendAccreditationNumberService = new SendAccreditationNumberService();
+  }
+
+  @Nested
+  @DisplayName("send 메소드는")
+  class Describe_01 {
+
+    public void subject(String mobileNumber) {
+      final var command = new SendAccreditationNumberUsecase
+          .SendAccreditationNumberCommand(mobileNumber);
+
+      sendAccreditationNumberService.send(command);
+    }
+
+    @Nested
+    @DisplayName("가입되지 않은 휴대폰 번호로 호출 되었을 경우")
+    class Context_01 {
+
+      private final int origin = 100_000;
+      private final int bound = 1000_000;
+
+      @Test
+      @DisplayName("인증번호를 생성한다")
+      public void it_01() {
+        final String 가입되지_않은_휴대폰_번호 = "010-1234-5678";
+        final int 인증번호 = 123456;
+
+        subject(가입되지_않은_휴대폰_번호);
+
+        try (MockedStatic<AccreditationNumberUtil> utilities =
+                 Mockito.mockStatic(AccreditationNumberUtil.class)) {
+          utilities.when(() -> AccreditationNumberUtil.generate(origin, bound))
+              .thenReturn(인증번호);
+
+          assertThat(AccreditationNumberUtil
+              .generate(origin, bound)).isEqualTo(인증번호);
+
+        }
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
## 개요 
- 인증번호 발송 web <-> domain 연동

## 작업 내용
- web 모듈과 domain 모듈을 연동하였습니다
- 인증번호 생성 호출을 테스트했습니다.

## 참고 사항
- [static method 를 테스트하기 위한 mokito 라이브러리](https://www.baeldung.com/mockito-mock-static-methods)

## 질문 및 논의 필요

