### PR TITLE
mockito 버전을 올려라

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ subprojects {
 
     ext {
         springBootVersion = "2.3.4.RELEASE"
-        mockitoVersion = "3.4.0"
+        mockitoVersion = "3.11.1"
         lombokVersion = "1.18.12"
         awsSdkVersion = "1.12.5"
     }


### PR DESCRIPTION
## 개요 
- mockito 버전을 올려라

## 작업 내용
- 3.4.0 -> 3.11.1 로 버전을 올렸습니다.

## 참고 사항
- 3.4.0 은 static method을 사용할 때  MockitoExcension 과 호환되지 않는 이슈가 있습니다.
- 발생 예외 : org.mockito.exceptions.misusing.NotAMockException: Argument passed to Mockito.mockingDetails() should be a mock, but is an instance of class java.lang.Class!
- 이슈 : https://github.com/mockito/mockito/issues/1967

## 질문 및 논의 필요

