### PR TITLE
SMS 발송 서비스 domain <-> notification 을 연동하라

### DIFF
--- a/adapters/notification/adapter-aws-sns/build.gradle
+++ b/adapters/notification/adapter-aws-sns/build.gradle
@@ -3,6 +3,7 @@ jar.enabled = true
 
 dependencies {
     implementation project(':common')
+    implementation project(':domain')
     implementation project(':test-support')
     implementation 'com.amazonaws:aws-java-sdk-sns'
 }

--- a/adapters/notification/adapter-aws-sns/src/main/java/com/caregiver/port/in/SendSmsMessageAdapter.java
+++ b/adapters/notification/adapter-aws-sns/src/main/java/com/caregiver/port/in/SendSmsMessageAdapter.java
@@ -1,6 +1,7 @@
 package com.caregiver.port.in;
 
 import com.amazonaws.services.sns.model.PublishRequest;
+import com.caregiver.common.annotation.NotificationAdapter;
 import com.caregiver.config.AwsSnsClient;
 import com.caregiver.user.port.out.NotificationSmsPort;
 import lombok.RequiredArgsConstructor;
@@ -8,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 /**
  * SMS 문자 메세지를 보냅니다.
  */
+@NotificationAdapter
 @RequiredArgsConstructor
 public class SendSmsMessageAdapter implements NotificationSmsPort {
 

--- a/adapters/notification/adapter-aws-sns/src/main/java/com/caregiver/port/in/SendSmsMessageAdapter.java
+++ b/adapters/notification/adapter-aws-sns/src/main/java/com/caregiver/port/in/SendSmsMessageAdapter.java
@@ -1,0 +1,30 @@
+package com.caregiver.port.in;
+
+import com.amazonaws.services.sns.model.PublishRequest;
+import com.caregiver.config.AwsSnsClient;
+import com.caregiver.user.port.out.NotificationSmsPort;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * SMS 문자 메세지를 보냅니다.
+ */
+@RequiredArgsConstructor
+public class SendSmsMessageAdapter implements NotificationSmsPort {
+
+  private final AwsSnsClient awsSnsClient;
+
+  /**
+   * SMS 문자메세지를 보냅니다.
+   *
+   * @param notificationSmsCommand SMS 요청.
+   */
+  @Override
+  public void sendSmsMessage(NotificationSmsCommand notificationSmsCommand) {
+    awsSnsClient.snsClient()
+        .publish(
+            new PublishRequest().withMessage(notificationSmsCommand.getMessage())
+                .withPhoneNumber(notificationSmsCommand.concatCountryCodeMobile())
+                .withMessageAttributes(awsSnsClient.getMessageAttributeValue())
+        );
+  }
+}

--- a/adapters/notification/adapter-aws-sns/src/test/java/com/caregiver/common/BaseConfiguration.java
+++ b/adapters/notification/adapter-aws-sns/src/test/java/com/caregiver/common/BaseConfiguration.java
@@ -2,6 +2,7 @@ package com.caregiver.common;
 
 import com.caregiver.config.AwsDefaultCredential;
 import com.caregiver.config.AwsProperties;
+import com.caregiver.config.AwsSnsClient;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.ConfigFileApplicationContextInitializer;
 import org.springframework.test.context.ActiveProfiles;
@@ -13,7 +14,8 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
  */
 @ActiveProfiles("test")
 @ExtendWith(SpringExtension.class)
-@ContextConfiguration(classes = {AwsProperties.class, AwsDefaultCredential.class},
+@ContextConfiguration(classes = {AwsProperties.class, AwsDefaultCredential.class,
+    AwsSnsClient.class},
     initializers = ConfigFileApplicationContextInitializer.class)
 public class BaseConfiguration {
 

--- a/applications/client-api/build.gradle
+++ b/applications/client-api/build.gradle
@@ -6,6 +6,7 @@ jar.enabled = false
 // client Application 을 구성하는 의존성
 dependencies {
     implementation project(':domain')
+    implementation project(':adapters:notification:adapter-aws-sns')
     implementation project(':adapters:persistence:adapter-maria')
     implementation project(':adapters:web:adapter-client-api')
     implementation 'org.springframework.boot:spring-boot-starter'

--- a/common/src/main/java/com/caregiver/common/annotation/NotificationAdapter.java
+++ b/common/src/main/java/com/caregiver/common/annotation/NotificationAdapter.java
@@ -1,0 +1,20 @@
+package com.caregiver.common.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.stereotype.Component;
+
+
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Component
+public @interface NotificationAdapter {
+
+  @AliasFor(annotation = Component.class)
+  String value() default "";
+}

--- a/domain/src/main/java/com/caregiver/user/port/in/SendAccreditationNumberUsecase.java
+++ b/domain/src/main/java/com/caregiver/user/port/in/SendAccreditationNumberUsecase.java
@@ -1,24 +1,24 @@
 package com.caregiver.user.port.in;
 
 import com.caregiver.common.SelfValidating;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.Pattern;
-
-
 /**
- * 인증 번호 전송 Usecase
+ * 인증 번호 전송 Usecase.
  */
 public interface SendAccreditationNumberUsecase {
 
   /**
-   * 주어진 휴대폰 번호를 SMS 발송서버로 전송합니다.
+   * 주어진 휴대폰 번호를 SMS 발송서버로 보냅니다.
    */
   void send(SendAccreditationNumberCommand sendAccreditationNumberCommand);
 
-
+  /**
+   * 인증번호 전송 요청 객체.
+   */
   @Getter
   @EqualsAndHashCode(callSuper = false)
   class SendAccreditationNumberCommand extends SelfValidating<SendAccreditationNumberCommand> {

--- a/domain/src/main/java/com/caregiver/user/port/out/NotificationSmsPort.java
+++ b/domain/src/main/java/com/caregiver/user/port/out/NotificationSmsPort.java
@@ -1,0 +1,49 @@
+package com.caregiver.user.port.out;
+
+import com.caregiver.common.SelfValidating;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+/**
+ * notification SMS 발송 서버를 호출하기 위한 Port.
+ */
+public interface NotificationSmsPort {
+
+  void sendSmsMessage(NotificationSmsPort.NotificationSmsCommand notificationSmsCommand);
+
+  /**
+   * SMS 서비스 요청 객체를 생성합니다.
+   */
+  @Getter
+  @EqualsAndHashCode(callSuper = false)
+  class NotificationSmsCommand extends SelfValidating<NotificationSmsPort.NotificationSmsCommand> {
+
+    @NotBlank
+    private final String message;
+
+    @NotBlank
+    @Pattern(regexp = "(01[0-9])-(\\d{3,4})-(\\d{4})")
+    private final String mobile;
+
+    @NotBlank
+    private final String countryCode;
+
+    public NotificationSmsCommand(String message, String mobile, String countryCode) {
+      this.message = message;
+      this.mobile = mobile;
+      this.countryCode = countryCode;
+      this.validateSelf();
+    }
+
+    /**
+     * 국가번호와 휴대폰번호를 연결하여 리턴합니다.
+     */
+    public String concatCountryCodeMobile() {
+      return countryCode + mobile;
+    }
+
+  }
+
+}

--- a/domain/src/main/java/com/caregiver/user/service/SendAccreditationNumberService.java
+++ b/domain/src/main/java/com/caregiver/user/service/SendAccreditationNumberService.java
@@ -1,21 +1,39 @@
 package com.caregiver.user.service;
 
-import com.caregiver.common.annotation.UseCase;
-import com.caregiver.user.port.in.SendAccreditationNumberUsecase;
-
 import static com.caregiver.common.util.AccreditationNumberUtil.generate;
 
+import com.caregiver.common.annotation.UseCase;
+import com.caregiver.user.port.in.SendAccreditationNumberUsecase;
+import com.caregiver.user.port.out.NotificationSmsPort;
+import lombok.RequiredArgsConstructor;
+
 /**
- * 인증번호 전송 service
+ * 인증번호 전송 service.
  */
 @UseCase
+@RequiredArgsConstructor
 public class SendAccreditationNumberService implements SendAccreditationNumberUsecase {
+
+  private final NotificationSmsPort notificationSmsPort;
+  private static final String COUNTRY_CODE = "+82";
 
   @Override
   public void send(SendAccreditationNumberCommand sendAccreditationNumberCommand) {
 
     final var accreditationNumber = generate(1_000, 10_000);
 
+    notificationSmsPort.sendSmsMessage(
+        new NotificationSmsPort.NotificationSmsCommand(
+            accreditationNumberSmsMessage(accreditationNumber),
+            sendAccreditationNumberCommand.getMobile(),
+            COUNTRY_CODE
+        )
+    );
+
+  }
+
+  private String accreditationNumberSmsMessage(int accreditationNumber) {
+    return "[집사살롱] 집사살롱 인증번호 [" + accreditationNumber + "] 요청하신 인증번호를 입력해 주세요.";
   }
 
 }

--- a/domain/src/test/java/com/caregiver/user/service/SendAccreditationNumberServiceTest.java
+++ b/domain/src/test/java/com/caregiver/user/service/SendAccreditationNumberServiceTest.java
@@ -1,26 +1,34 @@
 
 package com.caregiver.user.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.caregiver.common.util.AccreditationNumberUtil;
 import com.caregiver.user.port.in.SendAccreditationNumberUsecase;
+import com.caregiver.user.port.out.NotificationSmsPort;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-@SuppressWarnings("NonAsciiCharacters")
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings({"NonAsciiCharacters", "CheckStyle"})
 @DisplayName("SendAccreditationNumberService 클래스")
 class SendAccreditationNumberServiceTest {
 
   private SendAccreditationNumberUsecase sendAccreditationNumberService;
 
+  @Mock
+  NotificationSmsPort notificationSmsPort;
+
   @BeforeEach
   void init() {
-    this.sendAccreditationNumberService = new SendAccreditationNumberService();
+    this.sendAccreditationNumberService = new SendAccreditationNumberService(notificationSmsPort);
   }
 
   @Nested
@@ -35,7 +43,7 @@ class SendAccreditationNumberServiceTest {
     }
 
     @Nested
-    @DisplayName("가입되지 않은 휴대폰 번호로 호출 되었을 경우")
+    @DisplayName("휴대폰 번호로 호출 되었을 경우")
     class Context_01 {
 
       private final int origin = 1_000;
@@ -44,10 +52,10 @@ class SendAccreditationNumberServiceTest {
       @Test
       @DisplayName("인증번호를 생성한다")
       public void it_01() {
-        final String 가입되지_않은_휴대폰_번호 = "010-1234-5678";
+        final String 휴대폰_번호 = "010-1234-5678";
         final int 인증번호 = 1234;
 
-        subject(가입되지_않은_휴대폰_번호);
+        subject(휴대폰_번호);
 
         try (MockedStatic<AccreditationNumberUtil> utilities =
                  Mockito.mockStatic(AccreditationNumberUtil.class)) {


### PR DESCRIPTION
## 개요 
- SMS 발송을 위해 SMS port <-> adapter 를 연동하였습니다.

## 작업 내용


## 참고 사항
- 해당 PR은 https://github.com/TuesdayGangnam/caregiver-salon/pull/55, https://github.com/TuesdayGangnam/caregiver-salon/pull/54 PR의 의존성을 갖고있습니다. 
- 코드 리뷰시 54, 55 PR의 내용은 무시하셔도 됩니다.

## 질문 및 논의 필요

