### PR TITLE
이미지 업로드를 구현하라

### DIFF
--- a/adapters/persistence/adapter-s3/build.gradle
+++ b/adapters/persistence/adapter-s3/build.gradle
@@ -1,0 +1,6 @@
+bootJar.enabled = false
+jar.enabled = true
+
+dependencies {
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws'
+}

--- a/adapters/persistence/adapter-s3/build.gradle
+++ b/adapters/persistence/adapter-s3/build.gradle
@@ -2,5 +2,6 @@ bootJar.enabled = false
 jar.enabled = true
 
 dependencies {
+    implementation project(':domain')
     implementation 'org.springframework.cloud:spring-cloud-starter-aws'
 }

--- a/adapters/persistence/adapter-s3/src/main/java/com/caregiver/config/AmazonS3Config.java
+++ b/adapters/persistence/adapter-s3/src/main/java/com/caregiver/config/AmazonS3Config.java
@@ -1,0 +1,37 @@
+package com.caregiver.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+public class AmazonS3Config {
+
+  @Value("${cloud.aws.credentials.access-key:default-aws-access-key}")
+  private String accessKey;
+
+  @Value("${cloud.aws.credentials.secret-key:default-aws-secret-key}")
+  private String secretKey;
+
+  @Value("${cloud.aws.region.static}")
+  private String region;
+
+  @Bean
+  @Primary
+  public BasicAWSCredentials awsCredentialsProvider() {
+    return new BasicAWSCredentials(accessKey, secretKey);
+  }
+
+  @Bean
+  public AmazonS3 amazonS3() {
+    return AmazonS3ClientBuilder.standard()
+        .withRegion(region)
+        .withCredentials(new AWSStaticCredentialsProvider(awsCredentialsProvider()))
+        .build();
+  }
+}

--- a/adapters/persistence/adapter-s3/src/main/java/com/caregiver/config/AmazonS3Config.java
+++ b/adapters/persistence/adapter-s3/src/main/java/com/caregiver/config/AmazonS3Config.java
@@ -4,6 +4,7 @@ import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import lombok.Getter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -20,6 +21,14 @@ public class AmazonS3Config {
 
   @Value("${cloud.aws.region.static}")
   private String region;
+
+  @Getter
+  @Value("${cloud.aws.s3.bucket}")
+  private String bucket;
+
+  @Getter
+  @Value("${cloud.aws.s3.image-path}")
+  private String imagePath;
 
   @Bean
   @Primary

--- a/adapters/persistence/adapter-s3/src/main/java/com/caregiver/port/in/UploadImageAdapter.java
+++ b/adapters/persistence/adapter-s3/src/main/java/com/caregiver/port/in/UploadImageAdapter.java
@@ -1,0 +1,45 @@
+package com.caregiver.port.in;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.caregiver.user.port.in.ImageUploadUseCase.RequestCommand;
+import com.caregiver.user.port.in.ImageUploadUseCase.ResponseCommand;
+import com.caregiver.user.port.out.ImageUploadPort;
+import java.io.File;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+
+@Slf4j
+@RequiredArgsConstructor
+public class UploadImageAdapter implements ImageUploadPort {
+
+  private final AmazonS3Client amazonS3Client;
+
+  @Value("${cloud.aws.s3.bucket}")
+  private String bucket;
+
+  @Override
+  public ResponseCommand upload(RequestCommand command) {
+    File uploadFile = command.getUploadFile();
+    String uploadImageUrl = putS3(uploadFile, command.getDirName() + File.separator + uploadFile.getName());
+    removeNewFile(uploadFile);
+
+    return ResponseCommand.of(uploadImageUrl);
+  }
+
+  private String putS3(File uploadFile, String fileName) {
+    amazonS3Client.putObject(new PutObjectRequest(bucket, fileName, uploadFile).withCannedAcl(
+        CannedAccessControlList.PublicRead));
+    return amazonS3Client.getUrl(bucket, fileName).toString();
+  }
+
+  private void removeNewFile(File targetFile) {
+    if (targetFile.delete()) {
+      log.info("파일이 삭제되었습니다.");
+    } else {
+      log.info("파일이 삭제되지 못했습니다.");
+    }
+  }
+}

--- a/adapters/persistence/adapter-s3/src/main/java/com/caregiver/port/in/UploadImageAdapter.java
+++ b/adapters/persistence/adapter-s3/src/main/java/com/caregiver/port/in/UploadImageAdapter.java
@@ -3,35 +3,40 @@ package com.caregiver.port.in;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.caregiver.config.AmazonS3Config;
 import com.caregiver.user.port.in.ImageUploadUseCase.RequestCommand;
 import com.caregiver.user.port.in.ImageUploadUseCase.ResponseCommand;
 import com.caregiver.user.port.out.ImageUploadPort;
 import java.io.File;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 
 @Slf4j
 @RequiredArgsConstructor
 public class UploadImageAdapter implements ImageUploadPort {
 
   private final AmazonS3Client amazonS3Client;
-
-  @Value("${cloud.aws.s3.bucket}")
-  private String bucket;
+  private final AmazonS3Config amazonS3Config;
 
   @Override
   public ResponseCommand upload(RequestCommand command) {
     File uploadFile = command.getUploadFile();
-    String uploadImageUrl = putS3(uploadFile, command.getDirName() + File.separator + uploadFile.getName());
+    String uploadImageUrl = putS3(
+        uploadFile,
+        amazonS3Config.getImagePath() + uploadFile.getName(),
+        amazonS3Config.getBucket()
+    );
     removeNewFile(uploadFile);
 
     return ResponseCommand.of(uploadImageUrl);
   }
 
-  private String putS3(File uploadFile, String fileName) {
-    amazonS3Client.putObject(new PutObjectRequest(bucket, fileName, uploadFile).withCannedAcl(
-        CannedAccessControlList.PublicRead));
+  private String putS3(File uploadFile, String fileName, String bucket) {
+    amazonS3Client.putObject(
+        new PutObjectRequest(bucket, fileName, uploadFile)
+            .withCannedAcl(CannedAccessControlList.PublicRead)
+    );
+
     return amazonS3Client.getUrl(bucket, fileName).toString();
   }
 

--- a/adapters/persistence/adapter-s3/src/main/java/com/caregiver/port/in/UploadImageAdapter.java
+++ b/adapters/persistence/adapter-s3/src/main/java/com/caregiver/port/in/UploadImageAdapter.java
@@ -11,6 +11,9 @@ import java.io.File;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * 이미지 업로드 어뎁터
+ */
 @Slf4j
 @RequiredArgsConstructor
 public class UploadImageAdapter implements ImageUploadPort {
@@ -18,6 +21,11 @@ public class UploadImageAdapter implements ImageUploadPort {
   private final AmazonS3Client amazonS3Client;
   private final AmazonS3Config amazonS3Config;
 
+  /**
+   * 파일을 업로드 합니다.
+   *
+   * @param command 파일을 업로드 하기 위한 커멘드
+   */
   @Override
   public ResponseCommand upload(RequestCommand command) {
     File uploadFile = command.getUploadFile();
@@ -31,6 +39,14 @@ public class UploadImageAdapter implements ImageUploadPort {
     return ResponseCommand.of(uploadImageUrl);
   }
 
+  /**
+   * 파일을 S3 에 업로드 합니다.
+   *
+   * @param uploadFile 업로드할 파일 객체
+   * @param fileName 업로드할 파일명
+   * @param bucket 업로드한 버킷
+   * @return 업로드한 파일의 경로
+   */
   private String putS3(File uploadFile, String fileName, String bucket) {
     amazonS3Client.putObject(
         new PutObjectRequest(bucket, fileName, uploadFile)
@@ -40,6 +56,11 @@ public class UploadImageAdapter implements ImageUploadPort {
     return amazonS3Client.getUrl(bucket, fileName).toString();
   }
 
+  /**
+   * 파일을 삭제 합니다.
+   *
+   * @param targetFile 삭제할 파일
+   */
   private void removeNewFile(File targetFile) {
     if (targetFile.delete()) {
       log.info("파일이 삭제되었습니다.");

--- a/adapters/persistence/adapter-s3/src/main/resources/application.yml
+++ b/adapters/persistence/adapter-s3/src/main/resources/application.yml
@@ -1,0 +1,15 @@
+spring:
+  profiles:
+    include: private
+
+cloud:
+  aws:
+    s3:
+      bucket: caregiver-salon
+    region:
+      static: ap-northeast-2
+    credentials:
+      access-key: ${caregiver.aws.secret-key}
+      secret-key: ${caregiver.aws.access-key}
+    stack:
+      auto: false

--- a/adapters/persistence/adapter-s3/src/main/resources/application.yml
+++ b/adapters/persistence/adapter-s3/src/main/resources/application.yml
@@ -5,6 +5,7 @@ spring:
 cloud:
   aws:
     s3:
+      image-path: image/
       bucket: caregiver-salon
     region:
       static: ap-northeast-2

--- a/adapters/persistence/adapter-s3/src/test/java/com/caregiver/AdapterUploadApplicationTest.java
+++ b/adapters/persistence/adapter-s3/src/test/java/com/caregiver/AdapterUploadApplicationTest.java
@@ -1,0 +1,10 @@
+package com.caregiver;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * Upload Application Junit Test를 실행하기 위한 클래스.
+ */
+@SpringBootApplication
+public class AdapterUploadApplicationTest {
+}

--- a/adapters/persistence/adapter-s3/src/test/java/com/caregiver/common/BaseConfiguration.java
+++ b/adapters/persistence/adapter-s3/src/test/java/com/caregiver/common/BaseConfiguration.java
@@ -1,0 +1,19 @@
+package com.caregiver.common;
+
+import com.caregiver.config.AmazonS3Config;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.ConfigFileApplicationContextInitializer;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+/**
+ * 테스트를 클래스에서 공통으로 필요로하는 정보를 관리하는 클래스.
+ */
+@ActiveProfiles("test")
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {AmazonS3Config.class},
+    initializers = ConfigFileApplicationContextInitializer.class)
+public class BaseConfiguration {
+
+}

--- a/adapters/persistence/adapter-s3/src/test/java/com/caregiver/port/in/UploadImageAdapterTest.java
+++ b/adapters/persistence/adapter-s3/src/test/java/com/caregiver/port/in/UploadImageAdapterTest.java
@@ -7,7 +7,7 @@ import com.caregiver.user.port.in.ImageUploadUseCase.RequestCommand;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.util.Arrays;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -27,7 +27,7 @@ public class UploadImageAdapterTest extends BaseConfiguration {
   @BeforeEach
   public void setUp(@TempDir File tempDir) throws IOException {
     File file = new File(tempDir, "test");
-    Files.write(file.toPath(), Arrays.asList("x", "y", "z"));
+    Files.write(file.toPath(), List.of("x", "y", "z"));
 
     requestCommand = RequestCommand.of(file);
   }

--- a/adapters/persistence/adapter-s3/src/test/java/com/caregiver/port/in/UploadImageAdapterTest.java
+++ b/adapters/persistence/adapter-s3/src/test/java/com/caregiver/port/in/UploadImageAdapterTest.java
@@ -2,6 +2,7 @@ package com.caregiver.port.in;
 
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.caregiver.common.BaseConfiguration;
+import com.caregiver.config.AmazonS3Config;
 import com.caregiver.user.port.in.ImageUploadUseCase.RequestCommand;
 import java.io.File;
 import java.io.IOException;
@@ -20,6 +21,9 @@ public class UploadImageAdapterTest extends BaseConfiguration {
   @Autowired
   AmazonS3Client amazonS3Client;
 
+  @Autowired
+  AmazonS3Config amazonS3Config;
+
   RequestCommand requestCommand;
 
   @BeforeEach
@@ -29,13 +33,13 @@ public class UploadImageAdapterTest extends BaseConfiguration {
 
     Files.write(file.toPath(), lines);
 
-    requestCommand = RequestCommand.of(file, "static");
+    requestCommand = RequestCommand.of(file);
   }
 
   @Test
   @DisplayName("aws S3 이미지 업로드를 테스트하라")
   public void aws_s3_이미지_업로드를_테스트하라() {
-    UploadImageAdapter uploadImageAdapter = new UploadImageAdapter(amazonS3Client);
+    UploadImageAdapter uploadImageAdapter = new UploadImageAdapter(amazonS3Client, amazonS3Config);
     uploadImageAdapter.upload(requestCommand);
   }
 }

--- a/adapters/persistence/adapter-s3/src/test/java/com/caregiver/port/in/UploadImageAdapterTest.java
+++ b/adapters/persistence/adapter-s3/src/test/java/com/caregiver/port/in/UploadImageAdapterTest.java
@@ -1,9 +1,12 @@
 package com.caregiver.port.in;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.caregiver.common.BaseConfiguration;
 import com.caregiver.config.AmazonS3Config;
 import com.caregiver.user.port.in.ImageUploadUseCase.RequestCommand;
+import com.caregiver.user.port.in.ImageUploadUseCase.ResponseCommand;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -36,6 +39,8 @@ public class UploadImageAdapterTest extends BaseConfiguration {
   @DisplayName("aws S3 이미지 업로드를 테스트하라")
   public void aws_s3_이미지_업로드를_테스트하라() {
     UploadImageAdapter uploadImageAdapter = new UploadImageAdapter(amazonS3Client, amazonS3Config);
-    uploadImageAdapter.upload(requestCommand);
+    ResponseCommand upload = uploadImageAdapter.upload(requestCommand);
+
+    assertThat(upload.getUploadImageUrl()).isNotBlank();
   }
 }

--- a/adapters/persistence/adapter-s3/src/test/java/com/caregiver/port/in/UploadImageAdapterTest.java
+++ b/adapters/persistence/adapter-s3/src/test/java/com/caregiver/port/in/UploadImageAdapterTest.java
@@ -8,7 +8,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Arrays;
-import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,7 +16,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 public class UploadImageAdapterTest extends BaseConfiguration {
 
-  // 테스트 코드에서 amazonS3Clint 를 어떻게 가져와야하는지 모르겠음
   @Autowired
   AmazonS3Client amazonS3Client;
 
@@ -29,9 +27,7 @@ public class UploadImageAdapterTest extends BaseConfiguration {
   @BeforeEach
   public void setUp(@TempDir File tempDir) throws IOException {
     File file = new File(tempDir, "test");
-    List<String> lines = Arrays.asList("x", "y", "z");
-
-    Files.write(file.toPath(), lines);
+    Files.write(file.toPath(), Arrays.asList("x", "y", "z"));
 
     requestCommand = RequestCommand.of(file);
   }

--- a/adapters/persistence/adapter-s3/src/test/java/com/caregiver/port/in/UploadImageAdapterTest.java
+++ b/adapters/persistence/adapter-s3/src/test/java/com/caregiver/port/in/UploadImageAdapterTest.java
@@ -1,0 +1,41 @@
+package com.caregiver.port.in;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.caregiver.common.BaseConfiguration;
+import com.caregiver.user.port.in.ImageUploadUseCase.RequestCommand;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class UploadImageAdapterTest extends BaseConfiguration {
+
+  // 테스트 코드에서 amazonS3Clint 를 어떻게 가져와야하는지 모르겠음
+  @Autowired
+  AmazonS3Client amazonS3Client;
+
+  RequestCommand requestCommand;
+
+  @BeforeEach
+  public void setUp(@TempDir File tempDir) throws IOException {
+    File file = new File(tempDir, "test");
+    List<String> lines = Arrays.asList("x", "y", "z");
+
+    Files.write(file.toPath(), lines);
+
+    requestCommand = RequestCommand.of(file, "static");
+  }
+
+  @Test
+  @DisplayName("aws S3 이미지 업로드를 테스트하라")
+  public void aws_s3_이미지_업로드를_테스트하라() {
+    UploadImageAdapter uploadImageAdapter = new UploadImageAdapter(amazonS3Client);
+    uploadImageAdapter.upload(requestCommand);
+  }
+}

--- a/adapters/web/adapter-client-api/src/main/java/com/caregiver/user/controller/ImageUploadController.java
+++ b/adapters/web/adapter-client-api/src/main/java/com/caregiver/user/controller/ImageUploadController.java
@@ -29,19 +29,18 @@ public class ImageUploadController {
     File file = convert(multipartFile)
         .orElseThrow(() -> new IllegalArgumentException("MultipartFile -> File로 전환이 실패했습니다."));
 
-    imageUploadUseCase.upload(ImageUploadUseCase.RequestCommand.of(file, "static"));
+    imageUploadUseCase.upload(ImageUploadUseCase.RequestCommand.of(file));
 
     return ResponseEntity
         .status(HttpStatus.CREATED)
         .build();
   }
 
-    /**
-     *
-     * @param file
-     * @return
-     * @throws IOException
-     */
+  /**
+   * @param file
+   * @return
+   * @throws IOException
+   */
   private Optional<File> convert(MultipartFile file) throws IOException {
     File convertFile = new File(file.getOriginalFilename());
     if (convertFile.createNewFile()) {

--- a/adapters/web/adapter-client-api/src/main/java/com/caregiver/user/controller/ImageUploadController.java
+++ b/adapters/web/adapter-client-api/src/main/java/com/caregiver/user/controller/ImageUploadController.java
@@ -1,0 +1,56 @@
+package com.caregiver.user.controller;
+
+import com.caregiver.user.port.in.ImageUploadUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/v1/image")
+@RequiredArgsConstructor
+public class ImageUploadController {
+
+  private final ImageUploadUseCase imageUploadUseCase;
+
+  @PostMapping("/upload")
+  public ResponseEntity<?> acceptAccreditationNumber(
+      @RequestParam("data") MultipartFile multipartFile) throws IOException {
+
+    File file = convert(multipartFile)
+        .orElseThrow(() -> new IllegalArgumentException("MultipartFile -> File로 전환이 실패했습니다."));
+
+    imageUploadUseCase.upload(ImageUploadUseCase.RequestCommand.of(file, "static"));
+
+    return ResponseEntity
+        .status(HttpStatus.CREATED)
+        .build();
+  }
+
+    /**
+     *
+     * @param file
+     * @return
+     * @throws IOException
+     */
+  private Optional<File> convert(MultipartFile file) throws IOException {
+    File convertFile = new File(file.getOriginalFilename());
+    if (convertFile.createNewFile()) {
+      try (FileOutputStream fos = new FileOutputStream(convertFile)) {
+        fos.write(file.getBytes());
+      }
+      return Optional.of(convertFile);
+    }
+
+    return Optional.empty();
+  }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ subprojects {
     }
 
     ext {
+        springCloudVersion = "Hoxton.SR11"
         springBootVersion = "2.3.4.RELEASE"
         mockitoVersion = "3.11.1"
         lombokVersion = "1.18.12"
@@ -56,6 +57,7 @@ subprojects {
             //https://docs.spring.io/dependency-management-plugin/docs/current-SNAPSHOT/reference/html/#dependency-management-configuration-bom-import
             // 하위 모듈 내에서 이러한 종속성 중 하나가 필요한 경우 버전 번호가 dependencyManagement 클로저에서 로드되므로 버전 번호를 제공하지 않고 하위 모듈에서 지정할 수 있습니다.
             // 이를 통해 Maven의 pom.xml 파일에있는 <dependencyManagement> 요소와 매우 유사하게 여러 모듈에 배포하는 대신 단일 위치에서 버전 번호를 지정할 수 있습니다.
+            mavenBom"org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
             mavenBom"org.springframework.boot:spring-boot-dependencies:${springBootVersion}"
             mavenBom"com.amazonaws:aws-java-sdk-bom:${awsSdkVersion}"
         }

--- a/domain/src/main/java/com/caregiver/user/port/in/ImageUploadUseCase.java
+++ b/domain/src/main/java/com/caregiver/user/port/in/ImageUploadUseCase.java
@@ -23,10 +23,9 @@ public interface ImageUploadUseCase {
   @RequiredArgsConstructor
   class RequestCommand {
     private final File uploadFile;
-    private final String dirName;
 
-    public static RequestCommand of(File uploadFile, String dirName) {
-      return new RequestCommand(uploadFile, dirName);
+    public static RequestCommand of(File uploadFile) {
+      return new RequestCommand(uploadFile);
     }
   }
 

--- a/domain/src/main/java/com/caregiver/user/port/in/ImageUploadUseCase.java
+++ b/domain/src/main/java/com/caregiver/user/port/in/ImageUploadUseCase.java
@@ -1,0 +1,43 @@
+package com.caregiver.user.port.in;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Optional;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 이미지 업로드 UseCase
+ */
+public interface ImageUploadUseCase {
+
+  /**
+   * 주어진 이미지를 업로드 합니다.
+   */
+  ResponseCommand upload(RequestCommand command);
+
+  @Getter
+  @EqualsAndHashCode
+  @RequiredArgsConstructor
+  class RequestCommand {
+    private final File uploadFile;
+    private final String dirName;
+
+    public static RequestCommand of(File uploadFile, String dirName) {
+      return new RequestCommand(uploadFile, dirName);
+    }
+  }
+
+  @Getter
+  @EqualsAndHashCode
+  @RequiredArgsConstructor
+  class ResponseCommand {
+    private final String uploadImageUrl;
+
+    public static ResponseCommand of(String uploadImageUrl) {
+      return new ResponseCommand(uploadImageUrl);
+    }
+  }
+}

--- a/domain/src/main/java/com/caregiver/user/port/out/ImageUploadPort.java
+++ b/domain/src/main/java/com/caregiver/user/port/out/ImageUploadPort.java
@@ -1,0 +1,9 @@
+package com.caregiver.user.port.out;
+
+import com.caregiver.user.port.in.ImageUploadUseCase.RequestCommand;
+import com.caregiver.user.port.in.ImageUploadUseCase.ResponseCommand;
+
+public interface ImageUploadPort {
+
+  ResponseCommand upload(RequestCommand command);
+}

--- a/domain/src/main/java/com/caregiver/user/service/ImageUploadService.java
+++ b/domain/src/main/java/com/caregiver/user/service/ImageUploadService.java
@@ -4,9 +4,7 @@ import com.caregiver.common.annotation.UseCase;
 import com.caregiver.user.port.in.ImageUploadUseCase;
 import com.caregiver.user.port.out.ImageUploadPort;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @RequiredArgsConstructor
 @UseCase
 public class ImageUploadService implements ImageUploadUseCase {

--- a/domain/src/main/java/com/caregiver/user/service/ImageUploadService.java
+++ b/domain/src/main/java/com/caregiver/user/service/ImageUploadService.java
@@ -14,7 +14,7 @@ public class ImageUploadService implements ImageUploadUseCase {
   @Override
   public ResponseCommand upload(RequestCommand command) {
     imageUploadPort.upload(command);
-
+    // TODO: 응답값을 정의한 후 반환하는 코드 작성
     return ResponseCommand.of("임시업로드URL");
   }
 }

--- a/domain/src/main/java/com/caregiver/user/service/ImageUploadService.java
+++ b/domain/src/main/java/com/caregiver/user/service/ImageUploadService.java
@@ -1,0 +1,22 @@
+package com.caregiver.user.service;
+
+import com.caregiver.common.annotation.UseCase;
+import com.caregiver.user.port.in.ImageUploadUseCase;
+import com.caregiver.user.port.out.ImageUploadPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@UseCase
+public class ImageUploadService implements ImageUploadUseCase {
+
+  private final ImageUploadPort imageUploadPort;
+
+  @Override
+  public ResponseCommand upload(RequestCommand command) {
+    imageUploadPort.upload(command);
+
+    return ResponseCommand.of("임시업로드URL");
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,6 +8,7 @@ include 'domain'
 // adapter layer
 include 'adapters:notification:adapter-aws-sns'
 include 'adapters:persistence:adapter-maria'
+include 'adapters:persistence:adapter-s3'
 include 'adapters:web:adapter-client-api'
 include 'adapters:web:adapter-admin-api'
 


### PR DESCRIPTION
## 개요 
* 이미지 업로드를 구현하기 위해 S3 버킷을 할당하였습니다.
* AWS 계정은 [노션 문서](https://www.notion.so/f7ac8a7e9c754d7fa3e626d79bc860fc)의 dz-dark-brown 입니다
* S3 의 key는 [노션 문서](https://www.notion.so/f7ac8a7e9c754d7fa3e626d79bc860fc)에 있습니다.

## 작업 내용
* adapter-s3  모듈을 생성하였습니다.
* S3 에 파일을 업로드 하기 위해, 의존성과 configuration 설정을 완료하였습니다.

## 참고 사항
* 프리티어 S3 무료 구간
> AWS 프리 티어를 사용하는 고객은 Amazon S3를 무료로 시작할 수 있습니다. AWS 신규 가입 고객은 1년 동안 매달 5GB의 Amazon S3 스토리지(S3 Standard 스토리지 클래스), 20,000건의 GET 요청, 2,000건의 PUT, COPY, POST 또는 LIST 요청, 15GB의 데이터 송신 혜택을 받게 됩니다. 

출처: https://aws.amazon.com/ko/s3/pricing/

* S3 정책은 다음과 같이 주었습니다.
`
{
    "Version": "2012-10-17",
    "Id": "Policy1622876424748",
    "Statement": [
        {
            "Sid": "Stmt1622876421024",
            "Effect": "Allow",
            "Principal": "*",
            "Action": "s3:GetObject",
            "Resource": "arn:aws:s3:::{bucket명}/*"
        }
    ]
}
`

