### PR TITLE
ImageUploadPort 클래스 의존 오류를 해결하라

### DIFF
--- a/adapters/persistence/adapter-s3/build.gradle
+++ b/adapters/persistence/adapter-s3/build.gradle
@@ -2,6 +2,7 @@ bootJar.enabled = false
 jar.enabled = true
 
 dependencies {
+    implementation project(':common')
     implementation project(':domain')
     implementation 'org.springframework.cloud:spring-cloud-starter-aws'
 }

--- a/adapters/persistence/adapter-s3/src/main/java/com/caregiver/config/AmazonS3Config.java
+++ b/adapters/persistence/adapter-s3/src/main/java/com/caregiver/config/AmazonS3Config.java
@@ -10,6 +10,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 
+/**
+ * S3 환경 변수 Configuration.
+ */
 @Configuration
 public class AmazonS3Config {
 
@@ -30,12 +33,18 @@ public class AmazonS3Config {
   @Value("${cloud.aws.s3.image-path}")
   private String imagePath;
 
+  /**
+   * AWS 기본 인증이 완료된 Bean을 리턴합니다.
+   */
   @Bean
   @Primary
   public BasicAWSCredentials awsCredentialsProvider() {
     return new BasicAWSCredentials(accessKey, secretKey);
   }
 
+  /**
+   * AWS S3 Bean 을 리턴합니다.
+   */
   @Bean
   public AmazonS3 amazonS3() {
     return AmazonS3ClientBuilder.standard()

--- a/adapters/persistence/adapter-s3/src/main/java/com/caregiver/port/in/UploadImageAdapter.java
+++ b/adapters/persistence/adapter-s3/src/main/java/com/caregiver/port/in/UploadImageAdapter.java
@@ -3,6 +3,7 @@ package com.caregiver.port.in;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.caregiver.common.annotation.PersistenceAdapter;
 import com.caregiver.config.AmazonS3Config;
 import com.caregiver.user.port.in.ImageUploadUseCase.RequestCommand;
 import com.caregiver.user.port.in.ImageUploadUseCase.ResponseCommand;
@@ -12,9 +13,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * 이미지 업로드 어뎁터
+ * 이미지 업로드 어뎁터.
  */
 @Slf4j
+@PersistenceAdapter
 @RequiredArgsConstructor
 public class UploadImageAdapter implements ImageUploadPort {
 
@@ -43,8 +45,8 @@ public class UploadImageAdapter implements ImageUploadPort {
    * 파일을 S3 에 업로드 합니다.
    *
    * @param uploadFile 업로드할 파일 객체
-   * @param fileName 업로드할 파일명
-   * @param bucket 업로드한 버킷
+   * @param fileName   업로드할 파일명
+   * @param bucket     업로드한 버킷
    * @return 업로드한 파일의 경로
    */
   private String putS3(File uploadFile, String fileName, String bucket) {

--- a/applications/client-api/build.gradle
+++ b/applications/client-api/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     implementation project(':domain')
     implementation project(':adapters:notification:adapter-aws-sns')
     implementation project(':adapters:persistence:adapter-maria')
+    implementation project(':adapters:persistence:adapter-s3')
     implementation project(':adapters:web:adapter-client-api')
     implementation 'org.springframework.boot:spring-boot-starter'
 

--- a/applications/client-api/src/main/java/com/caregiver/AppClientApplication.java
+++ b/applications/client-api/src/main/java/com/caregiver/AppClientApplication.java
@@ -3,6 +3,9 @@ package com.caregiver;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+/**
+ * 집사살롱 회원을 대상으로 제공하는 API Application.
+ */
 @SpringBootApplication
 public class AppClientApplication {
 

--- a/common/src/main/java/com/caregiver/common/annotation/NotificationAdapter.java
+++ b/common/src/main/java/com/caregiver/common/annotation/NotificationAdapter.java
@@ -9,12 +9,18 @@ import org.springframework.core.annotation.AliasFor;
 import org.springframework.stereotype.Component;
 
 
+/**
+ * Notification layer 에서 사용될 Stereo Type 애노테이션.
+ */
 @Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Component
 public @interface NotificationAdapter {
 
+  /**
+   * Stereo Type 지정.
+   */
   @AliasFor(annotation = Component.class)
   String value() default "";
 }

--- a/common/src/main/java/com/caregiver/common/annotation/PersistenceAdapter.java
+++ b/common/src/main/java/com/caregiver/common/annotation/PersistenceAdapter.java
@@ -1,0 +1,26 @@
+package com.caregiver.common.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.stereotype.Component;
+
+
+/**
+ * Persistence layer 에서 사용될 Stereo Type 애노테이션.
+ */
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Component
+public @interface PersistenceAdapter {
+
+  /**
+   * Stereo Type 지정.
+   */
+  @AliasFor(annotation = Component.class)
+  String value() default "";
+}

--- a/common/src/main/java/com/caregiver/common/annotation/UseCase.java
+++ b/common/src/main/java/com/caregiver/common/annotation/UseCase.java
@@ -8,12 +8,19 @@ import java.lang.annotation.Target;
 import org.springframework.core.annotation.AliasFor;
 import org.springframework.stereotype.Component;
 
+
+/**
+ * Domain layer 에서 사용될 Stereo Type 애노테이션.
+ */
 @Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Component
 public @interface UseCase {
 
+  /**
+   * Stereo Type 지정.
+   */
   @AliasFor(annotation = Component.class)
   String value() default "";
 }

--- a/domain/src/main/java/com/caregiver/user/port/in/ImageUploadUseCase.java
+++ b/domain/src/main/java/com/caregiver/user/port/in/ImageUploadUseCase.java
@@ -1,15 +1,12 @@
 package com.caregiver.user.port.in;
 
 import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.util.Optional;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 /**
- * 이미지 업로드 UseCase
+ * 이미지 업로드 UseCase.
  */
 public interface ImageUploadUseCase {
 

--- a/domain/src/main/java/com/caregiver/user/port/out/ImageUploadPort.java
+++ b/domain/src/main/java/com/caregiver/user/port/out/ImageUploadPort.java
@@ -3,6 +3,9 @@ package com.caregiver.user.port.out;
 import com.caregiver.user.port.in.ImageUploadUseCase.RequestCommand;
 import com.caregiver.user.port.in.ImageUploadUseCase.ResponseCommand;
 
+/**
+ * 이미지를 업로드하기 위한 Port.
+ */
 public interface ImageUploadPort {
 
   ResponseCommand upload(RequestCommand command);

--- a/domain/src/main/java/com/caregiver/user/service/ImageUploadService.java
+++ b/domain/src/main/java/com/caregiver/user/service/ImageUploadService.java
@@ -5,6 +5,9 @@ import com.caregiver.user.port.in.ImageUploadUseCase;
 import com.caregiver.user.port.out.ImageUploadPort;
 import lombok.RequiredArgsConstructor;
 
+/**
+ * 이미지 업로드 service.
+ */
 @RequiredArgsConstructor
 @UseCase
 public class ImageUploadService implements ImageUploadUseCase {


### PR DESCRIPTION
## 개요 
- ImageUploadPort 이 빈으로 등록되지 않아 발생하는 의존성 오류를 해결하라

## 작업 내용
- Application layer에 s3 모듈을 추가하였습니다.

## 참고 사항
- 발생 오류
```
Consider defining a bean of type 'com.caregiver.user.port.out.ImageUploadPort' in your configuration.

```

## 질문 및 논의 필요

