### PR TITLE
웹 모듈을 jar 패키징 시 포함되도록 활성화 시켜라

### DIFF
--- a/adapters/web/adapter-client-api/build.gradle
+++ b/adapters/web/adapter-client-api/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'org.asciidoctor.convert'
 
-//bootJar.enabled = false
-//jar.enabled = true
+bootJar.enabled = false
+jar.enabled = true
 
 dependencies {
     implementation project(':domain')


### PR DESCRIPTION
## 개요 
- 웹 모듈을 jar 패키징 시 포함되도록 활성화 시켜라

## 작업 내용
- web 모듈의 `jar.enabled` 속성을 활성화 시켰습니다.

## 참고 사항


## 질문 및 논의 필요

