### PR TITLE
Spring REST Docs 가 활성화 되도록 gradle Task 를 수정하라

### DIFF
--- a/adapters/web/adapter-client-api/build.gradle
+++ b/adapters/web/adapter-client-api/build.gradle
@@ -28,7 +28,7 @@ asciidoctor {
     dependsOn test
 }
 
-bootJar {
+jar {
     dependsOn asciidoctor
     from("${asciidoctor.outputDir}/html5") {
         into "static/docs"


### PR DESCRIPTION
## 개요 
- web 모듈은 application 모듈에 의존되는 모듈이며 jar로 패키징 되기때문에 수정되어야합니다.

## 작업 내용
- bootJar -> jar 로 변경

## 참고 사항


## 질문 및 논의 필요

