### PR TITLE
API 요청이 성공한 경우라도 기본 공통 응답 객체를 리턴하도록 수정하라.

### DIFF
--- a/adapters/web/adapter-client-api/src/main/java/com/caregiver/common/error/ApiErrorResponse.java
+++ b/adapters/web/adapter-client-api/src/main/java/com/caregiver/common/error/ApiErrorResponse.java
@@ -94,7 +94,7 @@ public class ApiErrorResponse extends ApiResponseModel<Object> {
     }
 
     /**
-     * field, reason을 이용하여 생성한 사이즈가 1인 List<FieldError>를 리턴합니다.
+     * field, reason을 이용하여 생성한 사이즈가 1인 {@code List<FieldError>}를 리턴합니다.
      *
      * @param field  에러가 난 필드명
      * @param reason 사유
@@ -104,7 +104,7 @@ public class ApiErrorResponse extends ApiResponseModel<Object> {
     }
 
     /**
-     * bindingResult에서 field와 message를 추출하여 생성한 List<FieldError>를 리턴합니다.
+     * bindingResult에서 field와 message를 추출하여 생성한 {@code List<FieldError>}를 리턴합니다.
      *
      * @param bindingResult 실패한 유효성 검증 결과
      */
@@ -123,8 +123,8 @@ public class ApiErrorResponse extends ApiResponseModel<Object> {
     }
 
     /**
-     * constraintViolationException에서 propertyPath와 message를 추출하여 생성한 List<FieldError>를
-     * 리턴합니다.
+     * constraintViolationException에서 propertyPath와 message를 추출하여 생성한
+     * {@code List<FieldError>}를 리턴합니다.
      *
      * @param constraintViolationException 유효성 검증 실패
      */

--- a/adapters/web/adapter-client-api/src/main/java/com/caregiver/user/common/ApiResponseModel.java
+++ b/adapters/web/adapter-client-api/src/main/java/com/caregiver/user/common/ApiResponseModel.java
@@ -2,23 +2,36 @@ package com.caregiver.user.common;
 
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.ToString;
 
+/**
+ * API 공통 응답 클래스.
+ */
 @Getter
 @ToString
-@NoArgsConstructor
 public class ApiResponseModel<E> {
 
-  private boolean success;
-  private String message;
-  private E data;
+  private final boolean success;
+  private final String message;
+  private final E data;
 
+  /**
+   * ApiResponseModel 객체를 생성합니다.
+   */
   @Builder
   public ApiResponseModel(final boolean success, final String message, final E data) {
     this.success = success;
     this.message = message;
     this.data = data;
+  }
+
+  /**
+   * 기본 ApiResponseModel 객체를 생성합니다.
+   */
+  public ApiResponseModel() {
+    this.success = true;
+    this.message = "";
+    this.data = null;
   }
 
 }

--- a/adapters/web/adapter-client-api/src/main/java/com/caregiver/user/controller/MobileAuthenticationController.java
+++ b/adapters/web/adapter-client-api/src/main/java/com/caregiver/user/controller/MobileAuthenticationController.java
@@ -1,5 +1,6 @@
 package com.caregiver.user.controller;
 
+import com.caregiver.user.common.ApiResponseModel;
 import com.caregiver.user.dto.MobileAuthenticationDto;
 import com.caregiver.user.port.in.SendAccreditationNumberUsecase;
 import javax.validation.Valid;
@@ -27,14 +28,13 @@ public class MobileAuthenticationController {
    * @param request 인증번호를 요청하기위한 요청
    */
   @PostMapping("/accreditation-number/accept-sms")
-  public ResponseEntity<?> acceptAccreditationNumber(
+  public ResponseEntity<ApiResponseModel<?>> acceptAccreditationNumber(
       @RequestBody @Valid MobileAuthenticationDto.Request request) {
 
     sendAccreditationNumberUsecase.send(request.generateCommand());
-
     return ResponseEntity
         .status(HttpStatus.CREATED)
-        .build();
+        .body(new ApiResponseModel<>());
   }
 
 }

--- a/adapters/web/adapter-client-api/src/main/java/com/caregiver/user/dto/MobileAuthenticationDto.java
+++ b/adapters/web/adapter-client-api/src/main/java/com/caregiver/user/dto/MobileAuthenticationDto.java
@@ -1,20 +1,28 @@
 package com.caregiver.user.dto;
 
 import com.caregiver.user.port.in.SendAccreditationNumberUsecase;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.Pattern;
-
+/**
+ * 휴대폰 인증번호 요청 DTO.
+ */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class MobileAuthenticationDto {
 
+  /**
+   * 휴대폰 인증번호를 발송 요청 객체.
+   */
   @Getter
   @NoArgsConstructor
   public static class Request {
 
+    /**
+     * 휴대폰 번호.
+     */
     @NotBlank
     @Pattern(regexp = "(01[0-9])(\\d{3,4})(\\d{4})")
     private String mobile;

--- a/common/src/main/java/com/caregiver/common/SelfValidating.java
+++ b/common/src/main/java/com/caregiver/common/SelfValidating.java
@@ -1,14 +1,14 @@
 package com.caregiver.common;
 
 
+import java.util.Set;
 import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
 import javax.validation.Validation;
 import javax.validation.Validator;
-import java.util.Set;
 
 /**
- * Java Bean 유효성 검사를 하기 위한 클래스
+ * Java Bean 유효성 검사를 하기 위한 클래스.
  *
  * @param <T> 유효성 검사 대상 객체
  */
@@ -16,6 +16,9 @@ public abstract class SelfValidating<T extends SelfValidating<T>> {
 
   private final Validator validator;
 
+  /**
+   * SelfValidating 생성자.
+   */
   public SelfValidating() {
     validator = Validation
         .buildDefaultValidatorFactory()

--- a/common/src/main/java/com/caregiver/common/util/AccreditationNumberUtil.java
+++ b/common/src/main/java/com/caregiver/common/util/AccreditationNumberUtil.java
@@ -3,7 +3,7 @@ package com.caregiver.common.util;
 import java.util.concurrent.ThreadLocalRandom;
 
 /**
- * 인증번호 유틸 클래스
+ * 인증번호 유틸 클래스.
  */
 public class AccreditationNumberUtil {
 


### PR DESCRIPTION
## 개요 
- API 요청이 성공한 경우라도 공통 응답 객체를 리턴하도록 수정하라.

## 작업 내용
- 공통 응답 객체 생성자에 각 필드 기본 값 입력
- 휴대폰 인증 컨드롤러 정상 응답 시 공통 응답 객체 추가
- 누락 및 경고가 발생하는 javadoc 수정 

## 참고 사항


## 질문 및 논의 필요

