### PR TITLE
AWS SMS 실패시 예외를 응답하도록 수정하라

### DIFF
--- a/adapters/notification/adapter-aws-sns/src/main/java/com/caregiver/port/in/SendSmsMessageAdapter.java
+++ b/adapters/notification/adapter-aws-sns/src/main/java/com/caregiver/port/in/SendSmsMessageAdapter.java
@@ -1,14 +1,19 @@
 package com.caregiver.port.in;
 
+import static com.caregiver.common.exception.ErrorCode.INTERNAL_SERVER_ERROR;
+
 import com.amazonaws.services.sns.model.PublishRequest;
 import com.caregiver.common.annotation.NotificationAdapter;
+import com.caregiver.common.exception.BusinessException;
 import com.caregiver.config.AwsSnsClient;
 import com.caregiver.user.port.out.NotificationSmsPort;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * SMS 문자 메세지를 보냅니다.
  */
+@Slf4j
 @NotificationAdapter
 @RequiredArgsConstructor
 public class SendSmsMessageAdapter implements NotificationSmsPort {
@@ -18,15 +23,25 @@ public class SendSmsMessageAdapter implements NotificationSmsPort {
   /**
    * SMS 문자메세지를 보냅니다.
    *
-   * @param notificationSmsCommand SMS 요청.
+   * @param command SMS 요청.
    */
   @Override
-  public void sendSmsMessage(NotificationSmsCommand notificationSmsCommand) {
-    awsSnsClient.snsClient()
-        .publish(
-            new PublishRequest().withMessage(notificationSmsCommand.getMessage())
-                .withPhoneNumber(notificationSmsCommand.concatCountryCodeMobile())
-                .withMessageAttributes(awsSnsClient.getMessageAttributeValue())
-        );
+  public void sendSmsMessage(NotificationSmsCommand command) {
+    try {
+
+      awsSnsClient.snsClient()
+          .publish(
+              new PublishRequest()
+                  .withMessage(command.getMessage())
+                  .withPhoneNumber(command.concatCountryCodeMobile())
+                  .withMessageAttributes(awsSnsClient.getMessageAttributeValue())
+          );
+
+    } catch (RuntimeException e) {
+      log.error("AWS SMS publish 예외 mobile : {}, exception : {}",
+          command.getMobile(), e.getCause());
+      throw new BusinessException(INTERNAL_SERVER_ERROR, "SMS 문자 발송에 실패 하였습니다.");
+    }
   }
+
 }

--- a/adapters/notification/adapter-aws-sns/src/test/java/com/caregiver/common/BaseConfiguration.java
+++ b/adapters/notification/adapter-aws-sns/src/test/java/com/caregiver/common/BaseConfiguration.java
@@ -3,6 +3,7 @@ package com.caregiver.common;
 import com.caregiver.config.AwsProperties;
 import com.caregiver.config.AwsSnsClient;
 import com.caregiver.config.AwsSnsDefaultCredential;
+import com.caregiver.port.in.SendSmsMessageAdapter;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.ConfigFileApplicationContextInitializer;
 import org.springframework.test.context.ContextConfiguration;
@@ -13,7 +14,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = {AwsProperties.class, AwsSnsDefaultCredential.class,
-    AwsSnsClient.class},
+    AwsSnsClient.class, SendSmsMessageAdapter.class},
     initializers = ConfigFileApplicationContextInitializer.class)
 public class BaseConfiguration {
 

--- a/adapters/notification/adapter-aws-sns/src/test/java/com/caregiver/sms/SendSmsMessageAdapterTest.java
+++ b/adapters/notification/adapter-aws-sns/src/test/java/com/caregiver/sms/SendSmsMessageAdapterTest.java
@@ -1,18 +1,20 @@
 package com.caregiver.sms;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
 
 import com.amazonaws.services.sns.AmazonSNS;
-import com.amazonaws.services.sns.model.MessageAttributeValue;
 import com.amazonaws.services.sns.model.PublishRequest;
-import com.amazonaws.services.sns.model.PublishResult;
 import com.caregiver.common.BaseConfiguration;
 import com.caregiver.config.AwsSnsClient;
-import java.util.Map;
-import org.junit.jupiter.api.Disabled;
+import com.caregiver.config.AwsSnsClientFactory;
+import com.caregiver.port.in.SendSmsMessageAdapter;
+import com.caregiver.user.port.out.NotificationSmsPort;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
 /**
  * 문자메세지 발송 테스트.
@@ -20,33 +22,45 @@ import org.springframework.beans.factory.annotation.Autowired;
 @SuppressWarnings({"NonAsciiCharacters", "CheckStyle"})
 public class SendSmsMessageAdapterTest extends BaseConfiguration {
 
+  private static final String SMS_MESSAGE = "SMS 메세지";
+  private static final String PHONE_NUMBER = "01093793259";
+  private static final String COUNTRY_CODE = "+82";
+
   @Autowired
+  SendSmsMessageAdapter sendSmsMessageAdapter;
+
+  @MockBean
+  AwsSnsClientFactory awsSnsClientFactory;
+
+  @MockBean
   AwsSnsClient awsSnsClient;
+
+  @MockBean
+  AmazonSNS amazonSNS;
 
   /**
    * 테스트가 실행될 경우 SMS 문자 메세지를 발송합니다.
-   * 과금이 발생 요소가 있기에 Disabled 처리합니다.
-   * TODO 테스트 코드 목킹 그리고 리팩토링
    */
   @Test
-  @Disabled
   @DisplayName("aws Sms 메일 발송을 테스트하라")
   public void aws_sms_메일_발송을_테스트하라() {
 
-    final var snsClient = awsSnsClient.snsClient();
+    //given
+    NotificationSmsPort.NotificationSmsCommand command =
+        new NotificationSmsPort.NotificationSmsCommand(SMS_MESSAGE, PHONE_NUMBER, COUNTRY_CODE);
 
-    final var publishResult = sendSmsMessage(snsClient, "안녕하세요 이지훈입니다. 문자메세지 테스트",
-        "+8201012345678", awsSnsClient.getMessageAttributeValue());
+    final var publishRequest = new PublishRequest().withMessage(SMS_MESSAGE)
+        .withPhoneNumber(command.concatCountryCodeMobile())
+        .withMessageAttributes(awsSnsClient.getMessageAttributeValue());
 
-    assertThat(publishResult.getMessageId()).isNotBlank();
-  }
+    given(awsSnsClient.snsClient()).willReturn(amazonSNS);
 
-  private PublishResult sendSmsMessage(AmazonSNS amazonSns, String message, String phoneNumber,
-                                       Map<String, MessageAttributeValue> smsAttributes) {
+    // when
+    sendSmsMessageAdapter.sendSmsMessage(command);
 
-    return amazonSns.publish(new PublishRequest().withMessage(message)
-        .withPhoneNumber(phoneNumber)
-        .withMessageAttributes(smsAttributes));
+    // then
+    verify(awsSnsClient, atLeastOnce()).snsClient();
+    verify(amazonSNS, atLeastOnce()).publish(publishRequest);
 
   }
 

--- a/domain/src/main/java/com/caregiver/user/port/out/NotificationSmsPort.java
+++ b/domain/src/main/java/com/caregiver/user/port/out/NotificationSmsPort.java
@@ -41,7 +41,7 @@ public interface NotificationSmsPort {
      * 국가번호와 휴대폰번호를 연결하여 리턴합니다.
      */
     public String concatCountryCodeMobile() {
-      return countryCode + mobile;
+      return this.countryCode + this.mobile;
     }
 
   }


### PR DESCRIPTION
## 개요 
- AWS SMS 장애로 인해 예외가 발생할 경우 예외 응답 메세지를 전달하도록 수정했습니다.

## 작업 내용
- AWS SMS 장애로 인해 예외가 발생할 경우 예외 응답 메세지를 전달하도록 수정
- AWS SMS 테스트 코드를 목킹하여 사용하도록 수정했습니다. 

## 참고 사항


## 질문 및 논의 필요

